### PR TITLE
Add new orders function for creating orders in a transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thatconference/api",
-  "version": "1.15.4",
+  "version": "1.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5441,9 +5441,9 @@
       }
     },
     "eslint": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.18.0.tgz",
-      "integrity": "sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.19.0.tgz",
+      "integrity": "sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -5612,9 +5612,9 @@
           }
         },
         "flatted": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
-          "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+          "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
           "dev": true
         },
         "glob-parent": {
@@ -5781,9 +5781,9 @@
           },
           "dependencies": {
             "ajv": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
-              "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+              "version": "7.0.4",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
+              "integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
               "dev": true,
               "requires": {
                 "fast-deep-equal": "^3.1.1",
@@ -11543,8 +11543,7 @@
         },
         "acorn": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "resolved": "",
           "dev": true
         },
         "ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thatconference/api",
   "description": "THAT-API shared library for all microservices",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "main": "index.js",
   "scripts": {
     "build": "rimraf __build__ && babel ./src -d ./__build__ --copy-files --ignore ./**/__tests__",
@@ -39,7 +39,7 @@
     "babel-jest": "^26.6.3",
     "concurrently": "^5.3.0",
     "dotenv": "^8.2.0",
-    "eslint": "^7.18.0",
+    "eslint": "^7.19.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^7.2.0",


### PR DESCRIPTION
Add new `orders` function for creating orders in a transaction checking for an order first
Function will fall out quietly if the order is already in place or create it if it isn't there. 
This change came about when PubSub seem to have sent three messages within a sub-second of each other and brinks made three duplicate orders. 