### PR TITLE
Remove `husky install` from all npm scripts. (v2.0.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,64 @@ Shared component library for the api microservices.
 
 @thatconference/api
 
+## Development guidelines
+
+- After initial clone of repository run:
+  - npm i
+  - npx husky install
+
+`husky install` is put under npm:prepare by default, though it causes many issues with this babel generated product when publishing, etc. For now it has to be manual. Putting `husky install` under npm:postinstall, doesn't work as it will try to run when the package is installed in a project.
+
+## Basic local testing
+
+Use npm linking to test locally with this package.
+
+Starting with that-api directory
+
+```sh
+cd that-api
+npm run validate
+npm run build
+cd __build__
+npm link
+cd ..
+npm run dev
+```
+
+Now at the api project e.g. that-api-members
+
+```sh
+cd that-api-members
+npm run validate
+npm link @thatconference/api
+npm run validate
+npm run start:watch
+```
+
+At this point the that-api-members project is running using the linked that-api package, not the one downloaded into its node_modules folder.
+
+So to undo this. I am not 100% sure this is correct, but it seems to work.
+
+Unlink the the package from that-api-members.
+
+```sh
+^c
+cd ~/tc/that-api-members
+npm unlink @thatconference/api
+npm i @thatconference/api
+```
+
+Stop the running code and unlink to remove the link from npm which removes it from global location `{prefix}/lib/node_modules/<package>`
+
+```sh
+^c
+cd ~/tc/that-api/
+npm unlink
+cd ..
+```
+
+When you unlink a package it removes it from packages.json, so we need to then add it back. This is why we removed the global link first so we could install and get the package, not the link.
+
 ## Publishing new versions
 
 1. ENSURE `package.json` version is updated to new semver value!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@thatconference/api",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thatconference/api",
-      "version": "2.0.1",
-      "hasInstallScript": true,
+      "version": "2.0.4",
       "license": "gpl-3.0",
       "dependencies": {
         "apollo-server": "2.22.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@thatconference/api",
   "description": "THAT-API shared library for all micro services",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "index.js",
   "scripts": {
-    "postinstall": "husky install",
     "build": "rimraf __build__ && babel ./src -d ./__build__ --copy-files --ignore ./**/__tests__",
     "postbuild": "cp ./package.json ./package-lock.json ./__build__",
     "dev": "nodemon -e js --watch src --ignore '*.test.js, *.tests.js' --exec npm run build",


### PR DESCRIPTION
Fixes v2.0.3 which wouldn't install into other packages

Remove `husky install` from all npm scripts. No logical way for it to work across us usages

When running under `npm:prepare` (default), it wants to run while in the `__build__` folder which doesn't have `.git` in it and requires other funky settings for something we don't event need to run at that point. 

When running under `npm:postinstall`, husky tries to run when the package is installed in another project (e.g. that-api-members). This blowing up as well. 

Not finding a clean way to handle the use of husky/babel/local publish requirements, the `husky install` call has been removed and will need to be run for new clones of the `that-api` project.