### PR TITLE
fix publishing error from 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thatconference/api",
   "description": "THAT-API shared library for all micro services",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "main": "index.js",
   "scripts": {
     "build": "rimraf __build__ && babel ./src -d ./__build__ --copy-files --ignore ./**/__tests__",


### PR DESCRIPTION
v2.8.2
Fixes publishing error with v2.8.1.
It is preferred to use this version.