### PR TITLE
feat: add method getNotificationPreferenceFor to external member store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thatconference/api",
   "description": "THAT-API shared library for all micro services",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "main": "index.js",
   "scripts": {
     "build": "rimraf __build__ && babel ./src -d ./__build__ --copy-files --ignore ./**/__tests__",

--- a/src/dataSources/cloudFirestore/memberExternal.js
+++ b/src/dataSources/cloudFirestore/memberExternal.js
@@ -97,7 +97,49 @@ const member = dbInstance => {
     return Promise.all(ids.map(id => getIdType(id)));
   }
 
-  return { get, batchFind, update, findMemberByStripeCustId, getSecureBatch };
+  function getNotificationPreferenceFor({ preferenceName, preferenceValue }) {
+    dlog(
+      'getNotificationPreferenceFor called for preference %s with value %o',
+      preferenceName,
+      preferenceValue,
+    );
+    if (
+      preferenceName === null ||
+      preferenceName === undefined ||
+      typeof preferenceName !== 'string' ||
+      preferenceName.includes('.')
+    ) {
+      throw new Error('preferenceName must be and alpha string value');
+    }
+    if (
+      preferenceValue === null ||
+      preferenceValue === undefined ||
+      typeof preferenceValue !== 'boolean'
+    ) {
+      throw new Error('preferenceValue must be a boolean value');
+    }
+    return memberCollection
+      .where(`notificationPreferences.${preferenceName}`, '==', preferenceValue)
+      .get()
+      .then(querySnap =>
+        querySnap.docs.map(m => {
+          const r = {
+            id: m.id,
+            ...m.data(),
+          };
+          return memberDateForge(r);
+        }),
+      );
+  }
+
+  return {
+    get,
+    batchFind,
+    update,
+    findMemberByStripeCustId,
+    getSecureBatch,
+    getNotificationPreferenceFor,
+  };
 };
 
 export default member;


### PR DESCRIPTION
## v3.5.0
Feature update to v3 of library.
Add method, `getNotificationPreferenceFor`, to external member store for use with engagement emails
There are no package updates in this pr
This update will need to be added to main branch as well